### PR TITLE
Release 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-14
+
 ### Added
 
 - Added an `image_a` output and an auto-output switch to `NO8D-A/B preview`; disabling the switch blocks only the connected downstream branch while keeping comparison previews active.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "no8d-controls"
 description = "NO8D custom nodes for LoRA stacking, image generation and mask editing, A/B preview, prompt captioning, image loading, and dataset saving in ComfyUI."
-version = "1.0.6"
+version = "1.0.7"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = ["json-repair>=0.61,<1"]


### PR DESCRIPTION
## What changed

- Bumped the Comfy Registry package version from `1.0.6` to `1.0.7`.
- Archived the current Unreleased changelog entries under `1.0.7` dated 2026-07-14.

## Why

The latest node, documentation, and default-workflow updates are already on `main`, but Comfy Registry rejected them under the existing `1.0.6` version. A new semantic version is required for Manager installation.

## Impact

Merging this PR triggers the Comfy Registry workflow and publishes version `1.0.7` for installation through ComfyUI Manager.

## Validation

- 106 unit tests passed.
- Ruff checks passed.
- Python compilation passed.
- JavaScript syntax checks passed for 13 files.
- Release metadata and changelog checks passed.
