### PR TITLE
Release 1.0.10 prompt workflow fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.10] - 2026-07-17
+
+### Changed
+
+- Moved the fixed-prompt field from `NO8D-Prompt` to `NO8D-Prompt-view`, where it is prepended whenever text is emitted; connected legacy workflows migrate the saved value automatically.
+- Expanded the default weight range for new `NO8D-LoRA stack` entries from `-1..1` to `-2..2`.
+
+### Fixed
+
+- Prevented `NO8D-Prompt-view` from duplicating a fixed prefix across auto, edit, and Send flows while keeping cache signatures and visible editor text consistent.
+- Kept localized Prompt combo options compatible with mutable and function-backed ComfyUI option sources, including bilingual rule, length, and output-language values.
+
 ## [1.0.9] - 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Expand text, analyze a reference image, or combine both into a complete positive
 ![NO8D-Prompt](docs/images/prompt-plus-node.png)
 
 - Supports text-only, image-only, and text-plus-image input.
-- Provides style, shot-scale, prompt-length, and fixed-prefix controls.
+- Provides style, shot-scale, and prompt-length controls.
 - Allows separate text and vision model selection.
 
 ### NO8D-Prompt-view
@@ -53,6 +53,7 @@ Display and edit prompt text before sending it downstream.
 ![NO8D-Prompt-view](docs/images/prompt-view-node.png)
 
 - Automatically displays incoming prompt text.
+- Supports a fixed prompt that is prepended whenever the node emits text.
 - Supports manual editing and one-click downstream sending.
 - Can temporarily stop automatic text output without losing the editor content.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,7 +48,7 @@ git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 ![NO8D-提示词](docs/images/prompt-plus-node.png)
 
 - 支持纯文本、纯图像和文本加图像三种输入。
-- 提供风格、景别、提示词长度和固定前缀控制。
+- 提供风格、景别和提示词长度控制。
 - 可分别选择文本模型和图像模型。
 
 ### NO8D-提示词预览
@@ -58,6 +58,7 @@ git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 ![NO8D-提示词预览](docs/images/prompt-view-node.png)
 
 - 自动显示上游提示词。
+- 可填写固定提示词，并在实际输出时作为固定前缀拼接。
 - 支持手动编辑并一键发送到下游。
 - 可暂停自动文本输出，同时保留编辑内容。
 

--- a/examples/NO8D-controls-example.json
+++ b/examples/NO8D-controls-example.json
@@ -928,7 +928,6 @@
         "Standard",
         "English",
         "",
-        "",
         9,
         "fixed"
       ]
@@ -973,6 +972,7 @@
       },
       "widgets_values": [
         true,
+        "",
         "",
         "0",
         null

--- a/prompt_plus.py
+++ b/prompt_plus.py
@@ -1063,6 +1063,14 @@ def _limit_prompt_to_approx_tokens(text, target_tokens):
 def _join_prompt_parts(fixed_text="", prompt_text=""):
     fixed = _finish_fixed_prompt(fixed_text)
     prompt = str(prompt_text or "").strip()
+    if not fixed:
+        return prompt
+    if not prompt:
+        return fixed
+    raw_fixed = str(fixed_text or "").strip()
+    for prefix in dict.fromkeys(part for part in (fixed, raw_fixed) if part):
+        if prompt == prefix or prompt.startswith(prefix + "\n"):
+            return prompt
     return "\n".join(part for part in (fixed, prompt) if part)
 
 
@@ -1825,7 +1833,6 @@ class NO8DBatchPromptPlus:
                 "composition_preset": (_COMPOSITION_PRESET_INPUTS, {"default": "自行判断"}),
                 "length_preset": (_LENGTH_PRESET_INPUTS, {"default": "标准"}),
                 "output_language": (_OUTPUT_LANGUAGE_INPUTS, {"default": "英文"}),
-                "fixed_text": ("STRING", {"default": ""}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF, "control_after_generate": True}),
                 "extra_rules": ("STRING", {"default": "", "multiline": True}),
             },
@@ -1845,7 +1852,7 @@ class NO8DBatchPromptPlus:
     CATEGORY = "NO8D-control"
 
     @classmethod
-    def IS_CHANGED(cls, prompt_rules, style_preset="自行判断", composition_preset="自行判断", length_preset="标准", output_language="英文", fixed_text="", seed=0, extra_rules="", images=None, prompt=None, unique_id=None):
+    def IS_CHANGED(cls, prompt_rules, style_preset="自行判断", composition_preset="自行判断", length_preset="标准", output_language="英文", seed=0, extra_rules="", images=None, prompt=None, unique_id=None):
         service, model_cfg = prompt_config_manager.current_service()
         image_hashes = _images_to_hashes(images)
         prompt_text = str(extra_rules or "").strip()
@@ -1867,7 +1874,6 @@ class NO8DBatchPromptPlus:
             "length_preset": length_preset,
             "length_preset_rule": _LENGTH_PRESET_RULES.get(length_preset, _LENGTH_PRESET_RULES["标准"]),
             "output_language": output_language,
-            "fixed_text": fixed_text,
             "service_id": service.get("id"),
             "service_type": service.get("type", "openai_compatible"),
             "api_base_url": service.get("base_url", ""),
@@ -2005,12 +2011,11 @@ class NO8DBatchPromptPlus:
             self._cache_put(cache_key, result)
         return result
 
-    def run(self, prompt_rules, style_preset="自行判断", composition_preset="自行判断", length_preset="标准", output_language="英文", fixed_text="", seed=0, extra_rules="", images=None, prompt=None, unique_id=None):
+    def run(self, prompt_rules, style_preset="自行判断", composition_preset="自行判断", length_preset="标准", output_language="英文", seed=0, extra_rules="", images=None, prompt=None, unique_id=None):
         encoded = _images_to_data_urls(images)
         prompt = str(extra_rules or "").strip()
-        fixed_text = str(fixed_text or "").strip()
         if not encoded and not prompt:
-            return ([fixed_text],) if fixed_text else ([],)
+            return ([],)
 
         service, model_cfg = prompt_config_manager.current_service()
         api_base_url = service.get("base_url", "")
@@ -2064,7 +2069,7 @@ class NO8DBatchPromptPlus:
                 }
                 for future in concurrent.futures.as_completed(future_map):
                     prompts[future_map[future]] = future.result()
-            return ([_join_prompt_parts(fixed_text, item) for item in prompts],)
+            return (prompts,)
 
         prompts = [
             self._generate_prompt_item(
@@ -2075,7 +2080,7 @@ class NO8DBatchPromptPlus:
             )
             for index, (image_data_url, image_hash) in enumerate(items)
         ]
-        return ([_join_prompt_parts(fixed_text, item) for item in prompts],)
+        return (prompts,)
 
 
 class NO8DPromptView:
@@ -2084,6 +2089,7 @@ class NO8DPromptView:
         return {
             "required": {
                 "auto_output": ("BOOLEAN", {"default": True, "label_on": "auto", "label_off": "edit"}),
+                "fixed_text": ("STRING", {"default": ""}),
                 "edited_text": ("STRING", {"default": "", "multiline": True}),
                 "send_seq": ("STRING", {"default": "0"}),
             },
@@ -2103,14 +2109,16 @@ class NO8DPromptView:
     CATEGORY = "NO8D-control"
 
     @classmethod
-    def IS_CHANGED(cls, auto_output, edited_text="", send_seq=0, text="", prompt=None, unique_id=None):
+    def IS_CHANGED(cls, auto_output, fixed_text="", edited_text="", send_seq=0, text="", prompt=None, unique_id=None):
         auto = _safe_bool(auto_output, True)
+        fixed = _prompt_view_text(fixed_text)
         incoming = _prompt_view_text(text)
         edited = _prompt_view_text(edited_text)
         sequence = _safe_int(send_seq, 0)
         if sequence > 0:
             payload = {
                 "mode": "send",
+                "fixed_text": fixed,
                 "edited_text": edited,
                 "send_seq": sequence,
                 "unique_id": unique_id,
@@ -2118,6 +2126,7 @@ class NO8DPromptView:
         elif auto:
             payload = {
                 "mode": "auto",
+                "fixed_text": fixed,
                 "text": incoming,
                 "unique_id": unique_id,
                 "linked_inputs": _linked_inputs_signature(prompt, unique_id, ("text",)),
@@ -2127,6 +2136,7 @@ class NO8DPromptView:
         else:
             payload = {
                 "mode": "edit",
+                "fixed_text": fixed,
                 "text": incoming,
                 "edited_text": edited,
                 "unique_id": unique_id,
@@ -2134,21 +2144,22 @@ class NO8DPromptView:
             }
         return hashlib.sha1(json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")).hexdigest()
 
-    def view(self, auto_output=True, edited_text="", send_seq=0, text="", prompt=None, unique_id=None):
+    def view(self, auto_output=True, fixed_text="", edited_text="", send_seq=0, text="", prompt=None, unique_id=None):
+        fixed = _prompt_view_text(fixed_text)
         incoming = _prompt_view_text(text)
         edited = _prompt_view_text(edited_text)
         incoming_output = incoming if incoming.strip() else ""
         edited_output = edited if edited.strip() else ""
         is_send = _safe_int(send_seq, 0) > 0
         if is_send:
-            output = edited_output
-            display_text = edited
+            output = _join_prompt_parts(fixed, edited_output)
+            display_text = output
         elif _safe_bool(auto_output, True):
-            output = incoming_output or edited_output
+            output = _join_prompt_parts(fixed, incoming_output or edited_output)
             display_text = output
         else:
             output = ""
-            display_text = incoming_output or edited
+            display_text = _join_prompt_parts(fixed, incoming_output or edited)
         return {
             "ui": {
                 "edited_text": [display_text],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "no8d-controls"
 description = "NO8D custom nodes for LoRA stacking, image generation and mask editing, A/B preview, prompt captioning, image loading, and dataset saving in ComfyUI."
-version = "1.0.9"
+version = "1.0.10"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = ["json-repair>=0.61,<1"]

--- a/tests/test_prompt_length.py
+++ b/tests/test_prompt_length.py
@@ -6,6 +6,26 @@ from test_prompt_camera_geometry import prompt_plus
 
 
 class PromptLengthTests(unittest.TestCase):
+    def test_backend_accepts_bilingual_length_values_for_comfy_validation(self):
+        inputs = prompt_plus.NO8DBatchPromptPlus.INPUT_TYPES()["required"]
+        self.assertEqual(inputs["length_preset"][0], ("标准", "详细", "Standard", "Detailed"))
+        self.assertEqual(prompt_plus._normalize_length_preset("Standard"), "标准")
+        self.assertEqual(prompt_plus._normalize_length_preset("Detailed"), "详细")
+
+    def test_backend_accepts_bilingual_language_values_for_comfy_validation(self):
+        inputs = prompt_plus.NO8DBatchPromptPlus.INPUT_TYPES()["required"]
+        self.assertEqual(inputs["output_language"][0], ("英文", "中文", "English", "Chinese"))
+        self.assertEqual(prompt_plus._normalize_output_language("English"), "英文")
+        self.assertEqual(prompt_plus._normalize_output_language("Chinese"), "中文")
+
+    def test_backend_accepts_english_prompt_rule_alias_for_comfy_validation(self):
+        options = prompt_plus.NO8DBatchPromptPlus.INPUT_TYPES()["required"]["prompt_rules"][0]
+        self.assertIn("Natural language", options)
+        self.assertEqual(
+            prompt_plus.prompt_config_manager.normalize_prompt_rule_name("Natural language"),
+            prompt_plus._RULE_NATURAL,
+        )
+
     def test_standard_mode_uses_256_token_limit(self):
         self.assertEqual(prompt_plus._max_tokens_for_length("标准"), 256)
         self.assertEqual(prompt_plus._max_tokens_for_length("Standard"), 256)

--- a/tests/test_prompt_view.py
+++ b/tests/test_prompt_view.py
@@ -6,6 +6,12 @@ from test_prompt_camera_geometry import prompt_plus
 
 
 class PromptViewTests(unittest.TestCase):
+    def test_fixed_text_belongs_only_to_prompt_view_node(self):
+        prompt_inputs = prompt_plus.NO8DBatchPromptPlus.INPUT_TYPES()["required"]
+        view_inputs = prompt_plus.NO8DPromptView.INPUT_TYPES()["required"]
+        self.assertNotIn("fixed_text", prompt_inputs)
+        self.assertIn("fixed_text", view_inputs)
+
     def test_run_with_upstream_and_auto_on_outputs_upstream(self):
         result = prompt_plus.NO8DPromptView().view(
             auto_output=True,
@@ -15,6 +21,17 @@ class PromptViewTests(unittest.TestCase):
         )
         self.assertEqual(result["result"], ("upstream prompt",))
         self.assertEqual(result["ui"]["edited_text"], ["upstream prompt"])
+
+    def test_auto_output_prefixes_upstream_with_fixed_text(self):
+        result = prompt_plus.NO8DPromptView().view(
+            auto_output=True,
+            fixed_text="atmospheric photography",
+            edited_text="manual draft",
+            text="upstream prompt",
+            unique_id="preview-fixed-auto-test",
+        )
+        self.assertEqual(result["result"], ("atmospheric photography.\nupstream prompt",))
+        self.assertEqual(result["ui"]["edited_text"], ["atmospheric photography.\nupstream prompt"])
 
     def test_run_with_upstream_and_auto_off_displays_upstream_and_outputs_empty(self):
         result = prompt_plus.NO8DPromptView().view(
@@ -26,6 +43,17 @@ class PromptViewTests(unittest.TestCase):
         self.assertEqual(result["result"], ("",))
         self.assertEqual(result["ui"]["edited_text"], ["upstream prompt"])
 
+    def test_auto_off_keeps_output_empty_even_with_fixed_text(self):
+        result = prompt_plus.NO8DPromptView().view(
+            auto_output=False,
+            fixed_text="atmospheric photography",
+            edited_text="manual draft",
+            text="upstream prompt",
+            unique_id="preview-fixed-edit-test",
+        )
+        self.assertEqual(result["result"], ("",))
+        self.assertEqual(result["ui"]["edited_text"], ["atmospheric photography.\nupstream prompt"])
+
     def test_run_without_upstream_and_auto_on_outputs_editor(self):
         result = prompt_plus.NO8DPromptView().view(
             auto_output=True,
@@ -34,6 +62,39 @@ class PromptViewTests(unittest.TestCase):
             unique_id="preview-test",
         )
         self.assertEqual(result["result"], ("manual draft",))
+
+    def test_auto_output_prefixes_editor_when_upstream_is_missing(self):
+        result = prompt_plus.NO8DPromptView().view(
+            auto_output=True,
+            fixed_text="atmospheric photography",
+            edited_text="manual draft",
+            text="",
+            unique_id="preview-fixed-editor-test",
+        )
+        self.assertEqual(result["result"], ("atmospheric photography.\nmanual draft",))
+
+    def test_auto_output_can_emit_fixed_text_alone(self):
+        result = prompt_plus.NO8DPromptView().view(
+            auto_output=True,
+            fixed_text="atmospheric photography",
+            edited_text="",
+            text="",
+            unique_id="preview-fixed-only-test",
+        )
+        self.assertEqual(result["result"], ("atmospheric photography.",))
+        self.assertEqual(result["ui"]["edited_text"], ["atmospheric photography."])
+
+    def test_fixed_text_is_not_duplicated_when_editor_already_contains_it(self):
+        combined = "atmospheric photography.\nmanual draft"
+        result = prompt_plus.NO8DPromptView().view(
+            auto_output=True,
+            fixed_text="atmospheric photography",
+            edited_text=combined,
+            text="",
+            unique_id="preview-fixed-idempotent-test",
+        )
+        self.assertEqual(result["result"], (combined,))
+        self.assertEqual(result["ui"]["edited_text"], [combined])
 
     def test_bypassed_upstream_empty_list_outputs_editor(self):
         result = prompt_plus.NO8DPromptView().view(
@@ -145,6 +206,41 @@ class PromptViewTests(unittest.TestCase):
                     unique_id="preview-send-test",
                 )
                 self.assertEqual(result["result"], ("sent manual prompt",))
+
+    def test_send_prefixes_editor_with_fixed_text(self):
+        result = prompt_plus.NO8DPromptView().view(
+            auto_output=False,
+            fixed_text="atmospheric photography",
+            edited_text="sent manual prompt",
+            send_seq="123",
+            text="upstream prompt",
+            unique_id="preview-fixed-send-test",
+        )
+        self.assertEqual(result["result"], ("atmospheric photography.\nsent manual prompt",))
+        self.assertEqual(result["ui"]["edited_text"], ["atmospheric photography.\nsent manual prompt"])
+
+    def test_send_does_not_duplicate_visible_fixed_text(self):
+        combined = "atmospheric photography.\nsent manual prompt"
+        result = prompt_plus.NO8DPromptView().view(
+            auto_output=False,
+            fixed_text="atmospheric photography",
+            edited_text=combined,
+            send_seq="123",
+            text="upstream prompt",
+            unique_id="preview-fixed-send-idempotent-test",
+        )
+        self.assertEqual(result["result"], (combined,))
+
+    def test_send_can_emit_fixed_text_alone(self):
+        result = prompt_plus.NO8DPromptView().view(
+            auto_output=False,
+            fixed_text="atmospheric photography",
+            edited_text="",
+            send_seq="123",
+            text="upstream prompt",
+            unique_id="preview-fixed-send-only-test",
+        )
+        self.assertEqual(result["result"], ("atmospheric photography.",))
 
     def test_send_with_empty_editor_outputs_empty(self):
         result = prompt_plus.NO8DPromptView().view(

--- a/web/prompt_plus_i18n.js
+++ b/web/prompt_plus_i18n.js
@@ -5,7 +5,7 @@ import { refreshBypassElements, registerWidgetBypassElements, wrapBypassRefresh 
 const PROMPT_NODE = "NO8DBatchPromptPlus";
 const PROMPT_VIEW = "NO8DPromptView";
 const PROMPT_NODE_CLASSES = new Set([PROMPT_NODE]);
-const STALE_PROMPT_WIDGETS = new Set(["user_prompt", "token_range", "auto_run", "seed_control"]);
+const STALE_PROMPT_WIDGETS = new Set(["user_prompt", "token_range", "auto_run", "seed_control", "fixed_text"]);
 const SEED_CONTROL_VALUES = new Set(["fixed", "randomize", "increment", "decrement"]);
 
 const WIDGET_LABELS = {
@@ -59,7 +59,7 @@ const LANGUAGE_DISPLAY = {
 };
 const LENGTH_VALUES = new Set([...Object.keys(LENGTH_DISPLAY), ...Object.values(LENGTH_DISPLAY)]);
 const LANGUAGE_VALUES = new Set([...Object.keys(LANGUAGE_DISPLAY), ...Object.values(LANGUAGE_DISPLAY)]);
-const PROMPT_WIDGET_ORDER = ["prompt_rules", "style_preset", "composition_preset", "length_preset", "output_language", "fixed_text", "extra_rules", "seed"];
+const PROMPT_WIDGET_ORDER = ["prompt_rules", "style_preset", "composition_preset", "length_preset", "output_language", "extra_rules", "seed"];
 const COMPOSITION_VALUE_ALIASES = {
     "Close shot": "Medium close-up",
     "Medium wide shot": "Full shot",
@@ -93,6 +93,50 @@ const STYLE_VALUE_ALIASES = {
     "3D realism": "数字艺术",
 };
 let activeLocale = "";
+
+function migrateLegacyWidgetValues(node, nodeName, info) {
+    const values = info?.widgets_values;
+    if (!Array.isArray(values)) return;
+    if (nodeName === PROMPT_NODE) {
+        const hasLegacyFixedText = values.length >= 9
+            && Number.isFinite(Number(values[7]))
+            && SEED_CONTROL_VALUES.has(String(values[8] || "").trim());
+        if (!hasLegacyFixedText) return;
+        node._no8dLegacyFixedText = String(values[5] ?? "");
+        values.splice(5, 1);
+        return;
+    }
+    if (nodeName === PROMPT_VIEW) {
+        const oldSendIndex = values.length >= 3 && values.length <= 4
+            && /^\d+$/.test(String(values[2] ?? ""));
+        if (oldSendIndex) values.splice(1, 0, "");
+    }
+}
+
+function migrateLegacyFixedTextToPreview(node) {
+    const legacy = String(node?._no8dLegacyFixedText || "");
+    if (!legacy) return;
+    const graph = node?.graph || app?.graph;
+    let transferred = false;
+    for (const output of node?.outputs || []) {
+        for (const linkId of output?.links || []) {
+            const link = graph?.links?.[linkId];
+            const target = graph?.getNodeById?.(link?.target_id);
+            if (nodeClass(target) !== PROMPT_VIEW) continue;
+            const fixed = (target.widgets || []).find((widget) => widget.name === "fixed_text");
+            if (!fixed) continue;
+            if (!String(fixed.value || "").trim()) {
+                fixed.value = legacy;
+                if (typeof fixed.inputEl?.value === "string") fixed.inputEl.value = legacy;
+            }
+            transferred = true;
+        }
+    }
+    if (transferred) {
+        delete node._no8dLegacyFixedText;
+        graph?.setDirtyCanvas?.(true, true);
+    }
+}
 
 function nodeClass(node) {
     return node?.comfyClass || node?.type || "";
@@ -179,7 +223,17 @@ function localizeComboOptions(widget, displayMap) {
     widget.value = localizeOptionValue(widget.value, displayMap);
     const values = widget.options?.values;
     if (Array.isArray(values)) {
-        widget.options.values = [...new Set(values.map((value) => localizeOptionValue(value, displayMap)))];
+        const localized = [...new Set(values.map((value) => localizeOptionValue(value, displayMap)))];
+        values.splice(0, values.length, ...localized);
+        widget.options.values = values;
+    } else if (typeof values === "function" && !widget._no8dLocalizedValues) {
+        const original = values;
+        widget._no8dLocalizedValues = true;
+        widget.options.values = function () {
+            const available = original.apply(this, arguments);
+            if (!Array.isArray(available)) return available;
+            return [...new Set(available.map((value) => localizeOptionValue(value, displayMap)))];
+        };
     }
 }
 
@@ -231,13 +285,16 @@ function applyWidgetLabels(node) {
     }
     changed = applySlotLabels(node.inputs) || changed;
     changed = applySlotLabels(node.outputs) || changed;
-    registerWidgetBypassElements(node, [
+    registerWidgetBypassElements(node, cls === PROMPT_VIEW ? [
+        "fixed_text",
+        "edited_text",
+        "auto_output",
+    ] : [
         "prompt_rules",
         "style_preset",
         "composition_preset",
         "length_preset",
         "output_language",
-        "fixed_text",
         "extra_rules",
         "seed",
     ]);
@@ -280,8 +337,15 @@ app.registerExtension({
         };
         const onConfigure = nodeType.prototype.onConfigure;
         nodeType.prototype.onConfigure = function () {
+            migrateLegacyWidgetValues(this, nodeData.name, arguments[0]);
             if (onConfigure) onConfigure.apply(this, arguments);
-            setTimeout(() => applyWidgetLabels(this), 0);
+            setTimeout(() => {
+                applyWidgetLabels(this);
+                if (nodeData.name === PROMPT_NODE) migrateLegacyFixedTextToPreview(this);
+            }, 0);
+            if (nodeData.name === PROMPT_NODE) {
+                setTimeout(() => migrateLegacyFixedTextToPreview(this), 500);
+            }
         };
     },
 });

--- a/web/prompt_view.js
+++ b/web/prompt_view.js
@@ -24,11 +24,6 @@ function setWidget(widget, value) {
 
 function hideInternalWidgets(node) {
     let changed = false;
-    if (Array.isArray(node.widgets)) {
-        const before = node.widgets.length;
-        node.widgets = node.widgets.filter((widget) => widget.name !== "fixed_text");
-        if (node.widgets.length !== before) changed = true;
-    }
     for (const widget of node.widgets || []) {
         if (widget.name !== "send_seq") continue;
         if (widget.value !== "0") {
@@ -71,6 +66,18 @@ function readEditorText(node) {
     if (!edited) return "";
     if (typeof edited.inputEl?.value === "string") return edited.inputEl.value;
     return String(edited.value || "");
+}
+
+function composeVisibleText(node, text) {
+    const rawFixed = String(findWidget(node, "fixed_text")?.value || "").trim();
+    const body = String(text || "").trim();
+    if (!rawFixed) return body;
+    const fixed = /[。！？；：、，,.!?:;…]["'”’）\])}】》]*$/.test(rawFixed) ? rawFixed : `${rawFixed}.`;
+    if (!body) return fixed;
+    if (body === fixed || body === rawFixed || body.startsWith(`${fixed}\n`) || body.startsWith(`${rawFixed}\n`)) {
+        return body;
+    }
+    return `${fixed}\n${body}`;
 }
 
 function captureEditorDraft(node) {
@@ -123,6 +130,16 @@ function syncNativeLabels(node) {
         edited.serializeValue = function () {
             return serializedEditorText(node);
         };
+    }
+    const fixed = findWidget(node, "fixed_text");
+    if (fixed) {
+        const label = t("promptFixedText");
+        if (fixed.label !== label || fixed.options?.label !== label) changed = true;
+        fixed.label = label;
+        fixed.options = fixed.options || {};
+        fixed.options.label = label;
+        fixed.options.placeholder = label;
+        if (fixed.inputEl) fixed.inputEl.placeholder = label;
     }
     const auto = findWidget(node, "auto_output");
     if (auto) {
@@ -245,7 +262,7 @@ function activate(node) {
     let changed = hideInternalWidgets(node);
     changed = ensureSendWidget(node) || changed;
     changed = syncNativeLabels(node) || changed;
-    registerWidgetBypassElements(node, ["edited_text", "auto_output"]);
+    registerWidgetBypassElements(node, ["fixed_text", "edited_text", "auto_output"]);
     refreshBypassElements(node);
     if (changed) {
         node.graph?.setDirtyCanvas?.(true, true);
@@ -294,7 +311,10 @@ app.registerExtension({
             if (onExecuted) onExecuted.apply(this, arguments);
             activate(this);
             const incoming = readIncomingFromMessage(message);
-            if (incoming) setIncomingText(this, incoming);
+            const auto = Boolean(findWidget(this, "auto_output")?.value);
+            if (!auto && !hasActiveTextLink(this)) {
+                restoreEditorDraft(this, composeVisibleText(this, draftBeforeExecution));
+            } else if (incoming) setIncomingText(this, incoming);
             else restoreEditorDraft(this, draftBeforeExecution);
         };
     },

--- a/web/slider_lora_stack.js
+++ b/web/slider_lora_stack.js
@@ -7,8 +7,8 @@ import { refreshBypassElements, registerBypassElement, wrapBypassRefresh } from 
 const NODE_NAME = "NO8DLoraStack";
 const STACK_MIN_WIDTH = 620;
 const STACK_BOTTOM_GAP = 16;
-const DEFAULT_WEIGHT_MIN = -1;
-const DEFAULT_WEIGHT_MAX = 1;
+const DEFAULT_WEIGHT_MIN = -2;
+const DEFAULT_WEIGHT_MAX = 2;
 const WEIGHT_STEP = 0.01;
 const WEIGHT_DIGITS = 2;
 const STACK_WRITE_DELAY = 120;


### PR DESCRIPTION
## What changed

- Moved fixed-prompt ownership from `NO8D-Prompt` to `NO8D-Prompt-view`.
- Added legacy workflow migration for saved fixed prompts and Prompt-view widget ordering.
- Made fixed-prefix composition idempotent across auto, edit, and Send flows.
- Improved localized Prompt combo handling for mutable and function-backed option sources.
- Added bilingual backend validation coverage for rule, length, and output-language values.
- Expanded new LoRA stack entries' default weight range to `-2..2`.
- Updated the example workflow, bilingual README, changelog, and package version `1.0.10`.

## Why

Fixed prompts belong at the final editable preview/output stage, where users can see exactly what will be emitted. The migration and idempotent composition preserve old workflows while preventing duplicate prefixes. The option-source changes keep localized workflows valid across ComfyUI widget implementations.

## Impact

Existing connected Prompt → Prompt-view workflows migrate automatically. Users can edit or send prompts without duplicated fixed text, bilingual workflows validate consistently, and new LoRA controls start with a wider useful range.

## Validation

- 21 Prompt-view tests passed.
- 9 prompt length/localization tests passed.
- Full suite: 117 tests passed.
- Ruff checks and Python compilation passed.
- JavaScript syntax checks passed for 13 files.
- Example workflow JSON, LoRA defaults, release metadata, and `git diff --check` passed.
