### PR TITLE
Release 1.1.1 documentation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-19
+
+### Changed
+
+- Moved the `NO8D-Krea2 Style Selector` section to the beginning of the node overview in both English and Chinese documentation.
+
 ## [1.1.0] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ An example workflow is included at [examples/NO8D-controls-example.json](example
 
 All nodes are available under the `NO8D-control` or `NO8D-controls` category.
 
+### NO8D-Krea2 Style Selector
+
+Browse Krea 2 styles visually and output the complete prompt for the selected style.
+
+![NO8D-Krea2 Style Selector](docs/images/krea2-style-selector-node.png)
+
+- Groups 285 styles into Photography, Anime & Illustration, Hand-Drawn Art, and Digital Art.
+- Shows nine responsive previews per page with mouse and keyboard navigation.
+- Displays localized style names while preserving the original English prompt output.
+
 ### NO8D-LoRA stack
 
 Manage multiple LoRAs in one node and apply them to a model without a CLIP input.
@@ -87,16 +97,6 @@ Compare two image streams with an interactive split preview.
 - Displays image A and image B with their original dimensions.
 - Supports list-page switching and single-stream history comparison.
 - Can pass image A downstream or disable that output branch.
-
-### NO8D-Krea2 Style Selector
-
-Browse Krea 2 styles visually and output the complete prompt for the selected style.
-
-![NO8D-Krea2 Style Selector](docs/images/krea2-style-selector-node.png)
-
-- Groups 285 styles into Photography, Anime & Illustration, Hand-Drawn Art, and Digital Art.
-- Shows nine responsive previews per page with mouse and keyboard navigation.
-- Displays localized style names while preserving the original English prompt output.
 
 ![NO8D Image Title and Image Grid](docs/images/image-title-grid-nodes.png)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,16 @@ git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 
 所有节点位于 `NO8D-control` 或 `NO8D-controls` 分类。
 
+### NO8D-Krea2风格选择
+
+通过示意图浏览 Krea 2 风格，并输出当前选中风格的完整提示词。
+
+![NO8D-Krea2风格选择](docs/images/krea2-style-selector-node.png)
+
+- 将 285 种风格归入写实摄影、动漫插图、手绘艺术和数字艺术四个大类。
+- 每页显示九宫格示意图，支持鼠标和键盘操作。
+- 中文环境显示中文风格名称，同时保持原始英文提示词输出。
+
 ### NO8D-LoRA 堆栈
 
 在一个节点中管理多个 LoRA，并在不接入 CLIP 的情况下应用到模型。
@@ -92,16 +102,6 @@ git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 - 显示图像 A、图像 B 及其原始尺寸。
 - 支持列表翻页和单路图像历史对比。
 - 可把图像 A 传递到下游，也可关闭该输出分支。
-
-### NO8D-Krea2风格选择
-
-通过示意图浏览 Krea 2 风格，并输出当前选中风格的完整提示词。
-
-![NO8D-Krea2风格选择](docs/images/krea2-style-selector-node.png)
-
-- 将 285 种风格归入写实摄影、动漫插图、手绘艺术和数字艺术四个大类。
-- 每页显示九宫格示意图，支持鼠标和键盘操作。
-- 中文环境显示中文风格名称，同时保持原始英文提示词输出。
 
 ![NO8D-图片标题与多图拼接](docs/images/image-title-grid-nodes.png)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "no8d-controls"
 description = "NO8D custom nodes for LoRA stacking, prompt generation, image loading, generation and masking, style selection, image comparison and composition, and dataset saving in ComfyUI."
-version = "1.1.0"
+version = "1.1.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = ["json-repair>=0.61,<1"]


### PR DESCRIPTION
## What changed

- Move the `NO8D-Krea2 Style Selector` section to the first position in the English node overview.
- Apply the same ordering to the Chinese node overview.
- Release the documentation update as version 1.1.1.

## Validation

- Confirmed Krea2 is the first node heading in both README files.
- Confirmed all referenced README images exist.
- `git diff --check` passed.
