### PR TITLE
Release 1.1.3 Patreon links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-07-19
+
+### Changed
+
+- Added light and full Patreon project-support links before and after the node overview in both English and Chinese documentation.
+
 ## [1.1.2] - 2026-07-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Restart ComfyUI and hard-refresh the browser page. No frontend build step is req
 
 An example workflow is included at [examples/NO8D-controls-example.json](examples/NO8D-controls-example.json).
 
+You can also follow NO8D on [Patreon](https://patreon.com/no8d) for project updates.
+
 ## Nodes
 
 All nodes are available under the `NO8D-control` or `NO8D-controls` category.
@@ -140,6 +142,10 @@ Create empty latents using common model-family and aspect-ratio presets.
 - Supports SD/SDXL, SD3/Flux/Krea2, and Flux2 presets.
 - Provides portrait and landscape aspect ratios.
 - Outputs the latent together with its calculated width and height.
+
+## Support the project
+
+If you find these nodes useful, follow the project on [Patreon](https://patreon.com/no8d) and support its continued development. Your support helps maintain the nodes and make future improvements possible.
 
 ## Prompt API configuration
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,8 @@ git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 
 项目内置示例工作流：[examples/NO8D-controls-example.json](examples/NO8D-controls-example.json)。
 
+也可以在 [Patreon](https://patreon.com/no8d) 关注 NO8D 的项目动态。
+
 ## 节点说明
 
 所有节点位于 `NO8D-control` 或 `NO8D-controls` 分类。
@@ -145,6 +147,10 @@ git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 - 支持 SD/SDXL、SD3/Flux/Krea2 和 Flux2 预设。
 - 提供常用竖图和横图比例。
 - 输出 latent 及计算后的宽度和高度。
+
+## 支持项目
+
+如果这个节点组对你有帮助，欢迎在 [Patreon](https://patreon.com/no8d) 关注项目动态并支持后续开发。你的支持将帮助节点持续维护和改进。
 
 ## 提示词 API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "no8d-controls"
 description = "NO8D custom nodes for LoRA stacking, prompt generation, image loading, generation and masking, style selection, image comparison and composition, and dataset saving in ComfyUI."
-version = "1.1.2"
+version = "1.1.3"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = ["json-repair>=0.61,<1"]


### PR DESCRIPTION
## What changed

- Add a light Patreon mention immediately before the node overview.
- Add a dedicated project-support section immediately after the node overview.
- Apply the same structure and tone to the English and Chinese README files.
- Release the documentation update as version 1.1.3.

## Validation

- Confirmed both README files contain exactly two `https://patreon.com/no8d` links.
- Confirmed the light mention precedes the node overview and the full guidance follows it.
- `git diff --check` passed.
