### PR TITLE
Improve README navigation and project guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,6 @@ Create empty latents using common model-family and aspect-ratio presets.
 - Provides portrait and landscape aspect ratios.
 - Outputs the latent together with its calculated width and height.
 
-## Support the project
-
-If you find these nodes useful, follow the project on [Patreon](https://patreon.com/no8d) and support its continued development. Your support helps maintain the nodes and make future improvements possible.
-
 ## Prompt API and LLM configuration
 
 `NO8D-Prompt` sends your text or reference image to a configured large language model (LLM), then returns the generated prompt. It can connect to an OpenAI-compatible API or a locally running Ollama service.
@@ -181,6 +177,10 @@ Open **ComfyUI Settings**, select **NO8D-control** in the left sidebar, then cli
 After saving, return to the Prompt settings page and select the service under **Default prompt API**. If no models appear, check the Base URL and API key, then validate the service again. For Ollama, make sure Ollama is running and the required model is already installed locally.
 
 API keys remain in the local ComfyUI environment and should never be committed to the repository.
+
+## More tips and experimental nodes
+
+For more usage tips, workflow ideas, and experimental NO8D nodes, visit [Patreon](https://patreon.com/no8d). You can also follow ongoing updates and support the project's continued development there.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This custom node pack provides an end-to-end optimization solution covering the 
 
 ![ComfyUI-NO8D-controls](docs/images/no8d-control-banner-readme.jpg)
 
+## Quick navigation
+
+[Installation](#installation) · [Nodes](#nodes) · [Prompt API & LLM](#prompt-api-and-llm-configuration) · [More tips](#more-tips-and-experimental-nodes) · [License](#license) · [Star History](#star-history)
+
 ## Installation
 
 Clone the repository into `ComfyUI/custom_nodes`:
@@ -185,3 +189,13 @@ For more usage tips, workflow ideas, and experimental NO8D nodes, visit [Patreon
 ## License
 
 MIT. See [LICENSE](./LICENSE).
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=no8d%2FComfyUI-NO8D-controls&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=no8d/ComfyUI-NO8D-controls&type=Date&theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=no8d/ComfyUI-NO8D-controls&type=Date">
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=no8d/ComfyUI-NO8D-controls&type=Date">
+  </picture>
+</a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,10 +153,6 @@ git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 - 提供常用竖图和横图比例。
 - 输出 latent 及计算后的宽度和高度。
 
-## 支持项目
-
-如果这个节点组对你有帮助，欢迎在 [Patreon](https://patreon.com/no8d) 关注项目动态并支持后续开发。你的支持将帮助节点持续维护和改进。
-
 ## 提示词 API 与 LLM 配置
 
 `NO8D-提示词` 会把文本或参考图发送给已配置的大语言模型（LLM），再返回生成后的提示词。节点支持连接 OpenAI 兼容 API，也支持本机运行的 Ollama 服务。
@@ -186,6 +182,10 @@ git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 保存后回到 Prompt 设置页，在 **Default prompt API（默认提示词 API）**中选中刚才配置的服务。如果没有显示模型，请检查 Base URL 和 API key，然后重新验证；使用 Ollama 时，还需确认 Ollama 已启动并已在本地安装所需模型。
 
 API key 仅保存在本地 ComfyUI 环境中，请勿提交到仓库。
+
+## 更多使用技巧与实验性节点
+
+想了解更多使用技巧、工作流思路和实验性 NO8D 节点，欢迎前往 [Patreon](https://patreon.com/no8d)。你也可以在那里关注后续动态并支持项目持续开发。
 
 ## 许可证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,10 @@
 
 ![ComfyUI-NO8D-controls](docs/images/no8d-control-banner-readme.jpg)
 
+## 快速导航
+
+[QQ 交流群](#qq-交流群) · [安装](#安装) · [节点说明](#节点说明) · [API 与 LLM 配置](#提示词-api-与-llm-配置) · [更多技巧](#更多使用技巧与实验性节点) · [许可证](#许可证) · [增长记录](#项目增长记录)
+
 ## QQ 交流群
 
 欢迎加入 **iAi互助会**，群号：`482570609`。
@@ -190,3 +194,13 @@ API key 仅保存在本地 ComfyUI 环境中，请勿提交到仓库。
 ## 许可证
 
 MIT。详见 [LICENSE](./LICENSE)。
+
+## 项目增长记录
+
+<a href="https://www.star-history.com/?repos=no8d%2FComfyUI-NO8D-controls&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=no8d/ComfyUI-NO8D-controls&type=Date&theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=no8d/ComfyUI-NO8D-controls&type=Date">
+    <img alt="NO8D 节点组 Star History 增长曲线" src="https://api.star-history.com/svg?repos=no8d/ComfyUI-NO8D-controls&type=Date">
+  </picture>
+</a>


### PR DESCRIPTION
## What changed

- Move the full Patreon guidance below the Prompt API and LLM tutorial.
- Reframe the Patreon section around additional usage tips, workflow ideas, and experimental NO8D nodes.
- Add compact quick navigation to the beginning of both README files.
- Add a light/dark-aware Star History chart as the final section of both README files.

## Why

The support prompt is more relevant after readers understand setup and usage, while navigation makes the growing documentation easier to scan. The Star History chart provides a visible record of project growth.

## Impact

Documentation only. No node code, version metadata, or Registry package changes are included.

## Validation

- Confirmed the branch changes only `README.md` and `README.zh-CN.md`.
- Confirmed every navigation target has a matching section.
- Confirmed the Patreon section follows the API/LLM guide in both languages.
- Confirmed Star History is the final section and its interactive page is reachable.
- `git diff --check` passed.
