### PR TITLE
Declare and validate XLSX dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ cd ComfyUI/custom_nodes
 git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 ```
 
+ComfyUI Manager installs the dependencies from `requirements.txt` automatically. If you clone or update the node manually, install them with **ComfyUI's Python environment**:
+
+```bash
+cd ComfyUI/custom_nodes/ComfyUI-NO8D-controls
+python -m pip install -r requirements.txt
+```
+
+For Windows Portable, run this from the portable root instead:
+
+```bat
+python_embeded\python.exe -m pip install -r ComfyUI\custom_nodes\ComfyUI-NO8D-controls\requirements.txt
+```
+
+`openpyxl` is required for importing and exporting XLSX prompt libraries. Do not install it into an unrelated system Python environment.
+
 Restart ComfyUI and hard-refresh the browser page. No frontend build step is required.
 
 An example workflow is included at [examples/NO8D-controls-example.json](examples/NO8D-controls-example.json).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,21 @@ cd ComfyUI/custom_nodes
 git clone https://github.com/no8d/ComfyUI-NO8D-controls.git
 ```
 
+通过 ComfyUI Manager 安装时，会自动读取 `requirements.txt` 并安装依赖。如果通过 Git 手动安装或更新，请使用 **ComfyUI 自己的 Python 环境**执行：
+
+```bash
+cd ComfyUI/custom_nodes/ComfyUI-NO8D-controls
+python -m pip install -r requirements.txt
+```
+
+Windows 便携版请在便携版根目录执行：
+
+```bat
+python_embeded\python.exe -m pip install -r ComfyUI\custom_nodes\ComfyUI-NO8D-controls\requirements.txt
+```
+
+导入和导出 XLSX 提示词库需要 `openpyxl`。请勿将它安装到与 ComfyUI 无关的系统 Python 环境中。
+
 安装后重启 ComfyUI，并在浏览器中强制刷新页面。不需要额外构建前端。
 
 项目内置示例工作流：[examples/NO8D-controls-example.json](examples/NO8D-controls-example.json)。

--- a/krea_style_selector.py
+++ b/krea_style_selector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import csv
 import io
+import importlib
 import asyncio
 import os
 import re
@@ -37,6 +38,17 @@ _DEFAULT_USER_CATEGORY = "全部"
 _ALLOWED_IMAGE_TYPES = {"image/png": ".png", "image/jpeg": ".jpg", "image/webp": ".webp"}
 _MAX_PREVIEW_BYTES = 15 * 1024 * 1024
 _VIRTUAL_LIBRARIES = ("收藏夹", "历史记录")
+_OPENPYXL_REQUIRED_MESSAGE = (
+    "XLSX import and export require openpyxl, but it is not installed in ComfyUI's Python environment. "
+    "Install this node's requirements.txt with ComfyUI Manager or ComfyUI's Python, then restart ComfyUI."
+)
+
+
+def _require_openpyxl():
+    try:
+        return importlib.import_module("openpyxl")
+    except ImportError as error:
+        raise RuntimeError(_OPENPYXL_REQUIRED_MESSAGE) from error
 
 
 def _user_root() -> Path:
@@ -617,11 +629,8 @@ def _parse_import(content: bytes, filename: str) -> list[dict]:
         values = [[line] for line in text.splitlines()] if suffix == ".txt" else list(csv.reader(io.StringIO(text)))
         return _rows_from_values(values)
     if suffix == ".xlsx":
-        try:
-            from openpyxl import load_workbook
-        except ImportError as error:
-            raise ValueError("XLSX import requires openpyxl") from error
-        workbook = load_workbook(io.BytesIO(content), read_only=True, data_only=True)
+        openpyxl = _require_openpyxl()
+        workbook = openpyxl.load_workbook(io.BytesIO(content), read_only=True, data_only=True)
         sheet = workbook.active
         return _rows_from_values([list(row) for row in sheet.iter_rows(values_only=True)])
     raise ValueError("Only TXT, CSV, and XLSX files are supported")
@@ -631,8 +640,8 @@ def _parse_import_bundle(content: bytes, filename: str) -> tuple[list[dict], dic
     rows = _parse_import(content, filename)
     if Path(filename).suffix.lower() != ".xlsx":
         return rows, {}, {}
-    from openpyxl import load_workbook
-    workbook = load_workbook(io.BytesIO(content), read_only=False, data_only=True)
+    openpyxl = _require_openpyxl()
+    workbook = openpyxl.load_workbook(io.BytesIO(content), read_only=False, data_only=True)
     sheet = next((candidate for candidate in workbook.worksheets if candidate.title != "_NO8D_DATA"), workbook.active)
     previews = {}
     for image in getattr(sheet, "_images", []):
@@ -665,7 +674,7 @@ def _parse_import_bundle(content: bytes, filename: str) -> tuple[list[dict], dic
 
 
 def _export_items_xlsx(items: list[dict], library: str) -> bytes:
-    from openpyxl import Workbook
+    openpyxl = _require_openpyxl()
     from openpyxl.drawing.image import Image as XLImage
     from openpyxl.styles import Alignment, Font, PatternFill
     from PIL import Image as PILImage
@@ -673,7 +682,7 @@ def _export_items_xlsx(items: list[dict], library: str) -> bytes:
     if not items:
         raise ValueError("No styles selected")
     state = _read_state()
-    workbook = Workbook()
+    workbook = openpyxl.Workbook()
     sheet = workbook.active
     sheet.title = re.sub(r"[\\/*?:\[\]]", "_", library)[:31] or "Library"
     sheet.freeze_panes = "A2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "no8d-controls"
 description = "NO8D custom nodes for LoRA stacking, prompt generation, image loading, generation and masking, style selection, image comparison and composition, and dataset saving in ComfyUI."
-version = "1.2.2"
+version = "1.2.3"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = ["json-repair>=0.61,<1", "openpyxl>=3.1,<4"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+json-repair>=0.61,<1
+openpyxl>=3.1,<4

--- a/tests/test_krea_style_selector.py
+++ b/tests/test_krea_style_selector.py
@@ -8,6 +8,7 @@ import unittest
 import os
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -43,6 +44,15 @@ SAMPLE_PREVIEW = base64.b64decode(
 
 
 class KreaStyleSelectorTests(unittest.TestCase):
+    def test_missing_openpyxl_reports_the_comfyui_dependency_install_path(self):
+        with mock.patch.object(module.importlib, "import_module", side_effect=ModuleNotFoundError("openpyxl")):
+            with self.assertRaisesRegex(RuntimeError, r"requirements\.txt.*ComfyUI"):
+                module._require_openpyxl()
+
+    def test_requirements_declares_the_xlsx_dependency(self):
+        requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+        self.assertIn("openpyxl>=3.1,<4", requirements)
+
     def test_library_manager_links_to_the_prompt_libraries_tutorial(self):
         source = WEB_MODULE_PATH.read_text(encoding="utf-8")
         self.assertIn("no8d-prompt-164632304", source)


### PR DESCRIPTION
## Summary

- add the root `requirements.txt` used by ComfyUI Manager, including `openpyxl>=3.1,<4` and the existing `json-repair` dependency
- centralize XLSX dependency detection so the node remains loadable and returns an actionable ComfyUI-environment installation message if `openpyxl` is still missing
- document automatic Manager installation and manual Desktop/Portable commands in both READMEs
- bump the package version to `1.2.3`

## Why

`openpyxl` was declared only in `pyproject.toml`, while ComfyUI Manager installs custom-node dependencies from the repository's root `requirements.txt`. Users could therefore install or update the node without receiving the XLSX dependency.

## Validation

- ComfyUI Desktop environment resolves both requirements successfully (`openpyxl 3.1.5`)
- 165 unit tests passed
- targeted missing-dependency and requirements declaration tests passed
- Ruff, Python compilation, and whitespace checks passed
