### PR TITLE
Release 1.4.1 UI compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-08-03
+
+### Fixed
+
+- Kept A/B right-click image actions working when ComfyUI exposes graph coordinates through array-like point objects.
+- Kept localized combo labels separate from the canonical values saved in workflows and sent to node backends.
+
 ## [1.4.0] - 2026-08-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "no8d-controls"
 description = "NO8D custom nodes for LoRA stacking, prompt generation, image loading, generation and masking, style selection, image comparison and composition, and dataset saving in ComfyUI."
-version = "1.4.0"
+version = "1.4.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = ["json-repair>=0.61,<1", "openpyxl>=3.1,<4"]

--- a/tests/test_image_grid.py
+++ b/tests/test_image_grid.py
@@ -175,6 +175,14 @@ class ImageGridTests(unittest.TestCase):
             ["图外顶部", "图内顶部", "中部", "图内底部", "图外底部"],
         )
 
+    def test_i18n_keeps_combo_values_canonical_and_translates_only_labels(self):
+        source = (
+            pathlib.Path(__file__).resolve().parents[1] / "web" / "node_titles_i18n.js"
+        ).read_text(encoding="utf-8")
+        self.assertIn("widget.options.getOptionLabel", source)
+        self.assertIn("widget.value = entry[canonicalIndex]", source)
+        self.assertNotIn("widget.value = t(entry[0])", source)
+
     def test_horizontal_uses_first_image_height(self):
         output = _compose([_image(100, 50, (1, 0, 0)), _image(30, 60, (0, 1, 0))])
         self.assertEqual(tuple(output.shape), (1, 70, 155, 3))

--- a/web/compare_slider_preview.js
+++ b/web/compare_slider_preview.js
@@ -279,9 +279,15 @@ function isSecondaryClick(event) {
     return event?.button === 2;
 }
 
+function isPointLike(value) {
+    return value != null
+        && Number.isFinite(Number(value[0]))
+        && Number.isFinite(Number(value[1]));
+}
+
 function selectNativeImageUnderPointer(node, canvas) {
     const graphMouse = canvas?.graph_mouse || app.canvas?.graph_mouse;
-    if (!Array.isArray(graphMouse) || !Array.isArray(node?.pos)) return;
+    if (!isPointLike(graphMouse) || !isPointLike(node?.pos)) return;
     selectNativeImageAt(node, [
         graphMouse[0] - node.pos[0],
         graphMouse[1] - node.pos[1],

--- a/web/node_titles_i18n.js
+++ b/web/node_titles_i18n.js
@@ -152,6 +152,10 @@ function titleForClass(className) {
     return key ? t(key) : "";
 }
 
+function normalizedComboValue(value) {
+    return String(value ?? "").trim().toLocaleLowerCase().replace(/[\s\-_/]+/g, "");
+}
+
 function scheduleNodeRefresh(node) {
     if (!node || PENDING_REFRESH.has(node)) return;
     PENDING_REFRESH.add(node);
@@ -186,14 +190,26 @@ function applyNodeTitle(node) {
         const entries = comboLabels[widget.name];
         if (!entries) continue;
         const current = String(widget.value ?? "");
-        const entry = entries.find(([, english, chinese]) => current === english || current === chinese);
-        if (entry) widget.value = t(entry[0]);
+        const normalizedCurrent = normalizedComboValue(current);
+        const entry = entries.find(([, english, chinese]) => (
+            normalizedCurrent === normalizedComboValue(english)
+            || normalizedCurrent === normalizedComboValue(chinese)
+        ));
+        const canonicalIndex = 2;
+        if (entry) widget.value = entry[canonicalIndex];
         else if (className === "NO8DImageTitle" && widget.name === "output_size") {
-            widget.value = t(entries[0][0]);
+            widget.value = entries[0][canonicalIndex];
             widget.callback?.(widget.value, app.canvas, node, app.canvas?.graph_mouse);
         }
         widget.options = widget.options || {};
-        widget.options.values = entries.map(([key]) => t(key));
+        widget.options.values = entries.map((entry) => entry[canonicalIndex]);
+        widget.options.getOptionLabel = (value) => {
+            const option = entries.find(([, english, chinese]) => (
+                normalizedComboValue(value) === normalizedComboValue(english)
+                || normalizedComboValue(value) === normalizedComboValue(chinese)
+            ));
+            return option ? t(option[0]) : value;
+        };
         changed = true;
     }
     const inputLabels = INPUT_LABELS[className] || {};


### PR DESCRIPTION
## What changed

- accept array-like graph coordinates when choosing the A/B image under the right-click pointer
- keep localized combo labels separate from the canonical values saved in workflows and sent to backends
- add a regression check for combo-value localization

## Scope

NO8D-image-size is intentionally excluded from this release.

## Validation

- 267 unit tests passed
- Python compileall passed
- node --check passed for both changed frontend scripts
- git diff --check passed